### PR TITLE
Allow RESET GPIO to be disabled in make menuconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
-sdkconfig*
+sdkconfig
+sdkconfig.old

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+sdkconfig*

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -76,10 +76,11 @@ menu "TFT Configuration"
 
     config RESET_GPIO
         int "RESET GPIO number"
-        range 0 34
+        range -1 34
         default 2
         help
             GPIO number (IOxx) to RESET.
+            When it is -1, the RESET isn't performed.
             Some GPIOs are used for other purposes (flash connections, etc.) and cannot be used to Reset.
             GPIOs 35-39 are input-only so cannot be used as outputs.
 


### PR DESCRIPTION
Allow the user to disable the RESET GPIO by entering a value of -1 in the make menuconfig entry for RESET GPIO number. The code already handles this case, so no changes required there. An example of a board that does not have a GPIO assigned to the LCD RESET pin, is the ODROID GO, which I happened to have.

Also added both build folder and sdkconfig files to .gitignore file.